### PR TITLE
Update to make .create spec requirements more clear

### DIFF
--- a/spec/001_song_basics_spec.rb
+++ b/spec/001_song_basics_spec.rb
@@ -66,7 +66,7 @@ describe "Song" do
   end
 
   describe ".create" do
-    it "initializes and saves the song" do
+    it "initializes, saves, and returns the song" do
       created_song = Song.create("Kaohsiung Christmas")
 
       expect(Song.all).to include(created_song)


### PR DESCRIPTION
Students have been failing this test with this and similar code:

```ruby
	def self.create(name) 
		Song.new(name).save
	end 
```

The test only passes with this code:

```ruby
	def self.create(name) 
		song = Song.new(name)
		song.save
		song
	end 
```

The test could be improved by making it more clear that the latter code is needed.